### PR TITLE
Update Maven surefire and add Surefire Junit5 Tree Reporter plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,8 @@
       <maven-shade-plugin-version>3.4.1</maven-shade-plugin-version>
       <maven-site-plugin-version>3.9.1</maven-site-plugin-version>
       <maven-source-plugin-version>3.2.1</maven-source-plugin-version>
-      <maven-surefire-plugin-version>3.0.0</maven-surefire-plugin-version>
+      <maven-surefire-plugin-version>3.1.0</maven-surefire-plugin-version>
+      <maven-surefire-junit5-tree-reporter-version>1.2.1</maven-surefire-junit5-tree-reporter-version>
       <maven-surefire-report-plugin-version>3.0.0</maven-surefire-report-plugin-version>
       <native-maven-plugin-version>0.9.20</native-maven-plugin-version>
       <nexus-staging-maven-plugin-version>1.6.13</nexus-staging-maven-plugin-version>
@@ -621,6 +622,13 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <version>${maven-surefire-plugin-version}</version>
+            <dependencies>
+               <dependency>
+                  <groupId>me.fabriciorby</groupId>
+                  <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                  <version>${maven-surefire-junit5-tree-reporter-version}</version>
+               </dependency>
+            </dependencies>
             <configuration>
                <skip>false</skip>
                <reportsDirectory>${project.build.directory}/${testreports.surefire}</reportsDirectory>
@@ -628,6 +636,21 @@
                   <include>**/*Tests.java</include>
                   <include>**/*Test.java</include>
                </includes>
+               <reportFormat>plain</reportFormat>
+               <consoleOutputReporter>
+                  <disable>true</disable>
+               </consoleOutputReporter>
+               <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter">
+                  <theme>UNICODE</theme>
+                  <printStacktraceOnError>true</printStacktraceOnError>
+                  <printStacktraceOnFailure>true</printStacktraceOnFailure>
+                  <printStdoutOnError>true</printStdoutOnError>
+                  <printStdoutOnFailure>true</printStdoutOnFailure>
+                  <printStdoutOnSuccess>false</printStdoutOnSuccess>
+                  <printStderrOnError>true</printStderrOnError>
+                  <printStderrOnFailure>true</printStderrOnFailure>
+                  <printStderrOnSuccess>false</printStderrOnSuccess>
+               </statelessTestsetInfoReporter>
             </configuration>
          </plugin>
 


### PR DESCRIPTION
The plugin will improve how JUnit tests are shown in Maven build output: https://github.com/fabriciorby/maven-surefire-junit5-tree-reporter