### PR TITLE
Migrate validation API to jakarta namespace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
       <spring-boot-version>3.1.4</spring-boot-version>
       <swagger-parser-version>2.1.16</swagger-parser-version>
       <tika-version>2.9.0</tika-version>
-      <validation-api-version>2.0.1.Final</validation-api-version>
+      <validation-api-version>3.0.2</validation-api-version>
       <vavr-version>0.10.4</vavr-version>
       <velocity-version>2.3</velocity-version>
       <viz-js-graphviz-java-version>2.1.3</viz-js-graphviz-java-version>
@@ -423,8 +423,8 @@
             <version>${tika-version}</version>
          </dependency>
          <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
             <version>${validation-api-version}</version>
          </dependency>
          <dependency>


### PR DESCRIPTION
Fix for [esmf-parent issue #11](https://github.com/eclipse-esmf/esmf-parent/issues/11)