### PR TITLE
Fix Java configuration for Spotless plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -671,11 +671,11 @@
                     <!-- General formats -->
                     <format>
                        <includes>
-                          <include>**/*.java</include>
                           <include>**/*.md</include>
                           <include>**/*.adoc</include>
                           <include>**/*.ttl</include>
                           <include>**/*.xml</include>
+                          <include>**/*.yml</include>
                        </includes>
                        <trimTrailingWhitespace/>
                        <endWithNewline/>
@@ -692,6 +692,10 @@
                        <version>${spotless-maven-plugin-eclipse.version}</version>
                        <file>${maven.multiModuleProjectDirectory}/.development/esmf-eclipse-codestyle.xml</file>
                     </eclipse>
+                    <trimTrailingWhitespace/>
+                    <endWithNewline/>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <lineEndings>UNIX</lineEndings>
                  </java>
               </configuration>
             </plugin>


### PR DESCRIPTION
Only one formatter can be applied to each file, so the general format check must
not be applied to .java files, otherwise the Java-specific formatter will be
skipped